### PR TITLE
fix: add ProofOp verifier to enhancement verification

### DIFF
--- a/crypto/merkle/proof.go
+++ b/crypto/merkle/proof.go
@@ -30,17 +30,25 @@ type ProofOperator interface {
 // and the last Merkle root will be verified with already known data
 type ProofOperators []ProofOperator
 
-func (poz ProofOperators) VerifyValue(root []byte, keypath string, value []byte) (err error) {
-	return poz.Verify(root, keypath, [][]byte{value})
+type ProofOpVerifier func(ProofOperator) error
+
+func (poz ProofOperators) VerifyValue(root []byte, keypath string, value []byte, verifiers ...ProofOpVerifier) (err error) {
+	return poz.Verify(root, keypath, [][]byte{value}, verifiers...)
 }
 
-func (poz ProofOperators) Verify(root []byte, keypath string, args [][]byte) (err error) {
+func (poz ProofOperators) Verify(root []byte, keypath string, args [][]byte, verifiers ...ProofOpVerifier) (err error) {
 	keys, err := KeyPathToKeys(keypath)
 	if err != nil {
 		return
 	}
 
 	for i, op := range poz {
+		for _, verifier := range verifiers {
+			if err := verifier(op); err != nil {
+				return err
+			}
+		}
+
 		key := op.GetKey()
 		if len(key) != 0 {
 			if len(keys) == 0 {
@@ -109,22 +117,22 @@ func (prt *ProofRuntime) DecodeProof(proof *Proof) (ProofOperators, error) {
 	return poz, nil
 }
 
-func (prt *ProofRuntime) VerifyValue(proof *Proof, root []byte, keypath string, value []byte) (err error) {
-	return prt.Verify(proof, root, keypath, [][]byte{value})
+func (prt *ProofRuntime) VerifyValue(proof *Proof, root []byte, keypath string, value []byte, verifiers ...ProofOpVerifier) (err error) {
+	return prt.Verify(proof, root, keypath, [][]byte{value}, verifiers...)
 }
 
 // TODO In the long run we'll need a method of classifcation of ops,
 // whether existence or absence or perhaps a third?
-func (prt *ProofRuntime) VerifyAbsence(proof *Proof, root []byte, keypath string) (err error) {
-	return prt.Verify(proof, root, keypath, nil)
+func (prt *ProofRuntime) VerifyAbsence(proof *Proof, root []byte, keypath string, verifiers ...ProofOpVerifier) (err error) {
+	return prt.Verify(proof, root, keypath, nil, verifiers...)
 }
 
-func (prt *ProofRuntime) Verify(proof *Proof, root []byte, keypath string, args [][]byte) (err error) {
+func (prt *ProofRuntime) Verify(proof *Proof, root []byte, keypath string, args [][]byte, verifiers ...ProofOpVerifier) (err error) {
 	poz, err := prt.DecodeProof(proof)
 	if err != nil {
 		return cmn.ErrorWrap(err, "decoding proof")
 	}
-	return poz.Verify(root, keypath, args)
+	return poz.Verify(root, keypath, args, verifiers...)
 }
 
 // DefaultProofRuntime only knows about Simple value

--- a/crypto/merkle/proof_test.go
+++ b/crypto/merkle/proof_test.go
@@ -1,6 +1,7 @@
 package merkle
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -134,6 +135,19 @@ func TestProofOperators(t *testing.T) {
 	popz = []ProofOperator{}
 	err = popz.Verify(bz("OUTPUT4"), "/KEY4/KEY2/KEY1", [][]byte{bz("INPUT1")})
 	assert.NotNil(t, err)
+
+	// Test OP Verifier 1
+	popz = []ProofOperator{op1, op2, op3, op4}
+	err = popz.VerifyValue(bz("OUTPUT4"), "/KEY4/KEY2/KEY1", bz("INPUT1"), func(operator ProofOperator) error {
+		return nil
+	})
+	assert.Nil(t, err)
+
+	err = popz.VerifyValue(bz("OUTPUT4"), "/KEY4/KEY2/KEY1", bz("INPUT1"), func(operator ProofOperator) error {
+		return fmt.Errorf("suspend")
+	})
+	assert.EqualError(t, err, "suspend")
+
 }
 
 func bz(s string) []byte {


### PR DESCRIPTION
### Description
This PR aims to solve the BSC Bridge exploitation issue.

### Rationale
BC to BSC cross-chain communication is based on the light client technique. A smart contract is deployed on BSC to track the consensus state of BC including the appHash (analogous to stateRoot of Ethereum), which is essentially a root of a verifiable key-value store implemented as an AVL tree. Messages coming from BC will be verified against the appHash so their integrity can be guaranteed.

The store allows consecutive key-value pairs to be proved in batch (better in performance than proving each one individually). However its range proof verification logic contains a critical bug that can be exploited to prove membership of arbitrary key-value pairs chosen by the attacker.

https://github.com/cosmos/iavl/blob/6c1300ae54a9bb851e77dbcc4ba4b21832279027/proof_path.go#L70

https://github.com/cosmos/iavl/blob/6c1300ae54a9bb851e77dbcc4ba4b21832279027/proof.go#L79

The root is calculated by hashing repeatedly (just like in Merkle proof) as in the pseudocode below:
![image](https://user-images.githubusercontent.com/7310198/194698858-6dd00e51-4829-42fd-ae1d-5d8d04871698.png)

 If both left and right exist, the digest will ignore the right field. Because of this, if the verification path contains all items with both left and right, the root is unchanged with any arbitrary right values (using the same leaf). This is one factor to be exploited.

This PR in tendermint will introduce `ProofOpVerifier` to disable following ProofOperation:
1. The absence proof operator;
2. The value proof operator with more than one leaves.
### Example
Refer to the UT.

### Changes
NA
